### PR TITLE
Fix input failing to get episode_title if not using tmdb.

### DIFF
--- a/input.py
+++ b/input.py
@@ -158,6 +158,8 @@ if defaultjob['type'] == 'tv':
         if ontmdb:
             print('get from tmdb')
             episode_title = get_episode_title(tmdbid, season, episode)
+        else:
+            episode_title = ''
         episode_title = survey.routines.input(
             'Episode Title: ', value=episode_title)
 


### PR DESCRIPTION
Closes #17 by using a blank episode title if tmdb is not being used to get it.