### PR TITLE
Implemented daemon deleting start_daemon flag to avoid multiple daemons.

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -2,6 +2,15 @@
 All flags are empty files with a .flag suffix.
 They are always found in the root directory of the project.
 
+> [!WARNING]
+> Flags are cleared upon starting the daemon. Therefore all permanent settings should be stored in `config.json`.
+
+# All flags
+To get a list of all flags, get the `ALL_FLAGS` variable from `functions/flags.py`.
+Here is an explanation of what each one does.
+- `start_daemon`: Starts a daemon process if none currently exist. Be warned that it does take >5 seconds to take effect.
+- `safe_stop_daemon`: Safely stops the currently running daemon process by making it wait until it completes all current jobs and then quitting.
+- `quick_stop_daemon`: Stops daemon by getting it to immediately kill itself. WARNING: THIS WILL CAUSE ALL CURRENTLY RUNNING JOBS TO FAIL.
 
 # Functions
 `functions/flags.py` contains some helpful functions to assist with flags. Here is each one.

--- a/functions/flags.py
+++ b/functions/flags.py
@@ -6,7 +6,13 @@ They are always found in the root directory of the project.
 
 from pathlib import Path
 
-from .config import load_config, PROJECT_ROOT
+from .config import PROJECT_ROOT
+
+ALL_FLAGS = [
+    'start_daemon',
+    'safe_stop_daemon',
+    'quick_stop_daemon',
+]
 
 
 def flag_name_to_path(flag_name: str) -> Path:


### PR DESCRIPTION
Changes to help with #8 
- Added `ALL_FLAGS` variable to make it easier to delete them all on startup.
- Changed daemon implementation of flags to just store the current flags in a list and print any changes.
- Changed `stop.flag` to `safe_stop_daemon.flag` (acts same way as `stop.flag`) and `quick_stop_daemon.flag` (removes all current jobs so that the program exits immediately).
- Daemon automatically deletes `start_daemon.flag` if detected to avoid having multiple daemons.
- Changed daemon to contain the conditions in the while loop parameters instead of an if statement that breaks it.