### PR TITLE
Added function to search TMDB by name instead of ID

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-TMDB_API_KEY=enteryourkeyhere
+TMDB_API_KEY=dummy_key_for_testing

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-TMDB_API_KEY=dummy_key_for_testing
+TMDB_API_KEY=enteryourkeyhere

--- a/daemon.py
+++ b/daemon.py
@@ -96,12 +96,10 @@ with data_lock:
 
         # 2. Reset jobs interrupted to 'not_started'
         elif status == "getting_frames":
-            print(f"Resetting interrupted job {
-                  uid} ({job.get('name', 'N/A')}) to 'not_started'.")
+            print(f"Resetting interrupted job {uid} ({job.get('name', 'N/A')}) to 'not_started'.")
             job["status"] = "not_started"
         elif status == "encoding":
-            print(f"Resetting interrupted job {
-                  uid} ({job.get('name', 'N/A')}) to 'ready_to_encode'.")
+            print(f"Resetting interrupted job {uid} ({job.get('name', 'N/A')}) to 'ready_to_encode'.")
             job["status"] = "ready_to_encode"
             try:
                 os.remove(job['encoded_file'])

--- a/functions/config.py
+++ b/functions/config.py
@@ -77,8 +77,7 @@ def load_config() -> Config:
         dotenv.load_dotenv(DOTENV_PATH)
     except Exception as e:
         # Handle cases where the .env file might not exist or be readable
-        print(f"Warning: Could not load .env file from {
-              DOTENV_PATH}. Error: {e}")
+        print(f"Warning: Could not load .env file from {DOTENV_PATH}. Error: {e}")
 
     raw_config_data = {}
 
@@ -87,8 +86,7 @@ def load_config() -> Config:
             with open(CONFIG_FILE_PATH, 'r') as f:
                 raw_config_data = json.load(f)
         except json.JSONDecodeError:
-            print(f"Error: Could not parse {
-                  CONFIG_FILE_PATH}. Check JSON syntax.")
+            print(f"Error: Could not parse {CONFIG_FILE_PATH}. Check JSON syntax.")
         except Exception as e:
             print(f"Error reading config file: {e}")
 

--- a/functions/t_status_data.py
+++ b/functions/t_status_data.py
@@ -140,8 +140,8 @@ def get_overview_data_table(
             output_table[job_id]["encoded"] += 1
     for job_id in output_table:
         try:
-            output_table[job_id]["progress"] = f'{
-                output_table[job_id]["encoded"]}/{output_table[job_id]["total"]}'
+            output_table[job_id]["progress"] = \
+                f'{output_table[job_id]["encoded"]}/{output_table[job_id]["total"]}'
             pct = output_table[job_id]["encoded"]/output_table[job_id]["total"]
             if pct == 0:
                 output_table[job_id]["status"] = "Not Started"

--- a/functions/tmdb_client.py
+++ b/functions/tmdb_client.py
@@ -1,6 +1,41 @@
 import tmdbsimple as tmdb
 
 
+def search_media_by_title(media_title: str, media_type: str) -> list[tmdb.tv.TV] | list[tmdb.movies.Movies]:
+    """
+    Search TMDB for media by title
+
+    Returns:
+        List of possible TMDB matches
+    """
+    try:
+        tmdb_objects = []
+
+        if media_type == 'tv':
+            results = tmdb.Search().tv(query=media_title)
+            for result in results.get('results', []):
+                media_id = result['id']
+                tmdb_object = tmdb.TV(media_id)
+                tmdb_objects.append(tmdb_object)
+            
+            return tmdb_objects
+        
+        elif media_type == 'movie':
+            results = tmdb.Search().movie(query=media_title)
+            for result in results.get('results', []):
+                media_id = result['id']
+                tmdb_object = tmdb.Movies(media_id)
+                tmdb_objects.append(tmdb_object)
+            
+            return tmdb_objects
+        
+        else:
+            return []   # Handle unexpected media_type
+        
+    except Exception:
+        return []
+
+
 def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
     """
     Fetch general info (title and year) about a TV show or movie from TMDB.

--- a/functions/tmdb_client.py
+++ b/functions/tmdb_client.py
@@ -36,6 +36,58 @@ def search_media_by_title(media_title: str, media_type: str) -> list[tmdb.tv.TV]
         return []
 
 
+def fetch_tmdb_object_details(media_id: int, media_type: str) -> dict:
+    """
+    Retrieve TMDB info() result for either TV or Movie.
+    Returns {} on failure.
+    """
+    try:
+        if media_type == "tv":
+            return tmdb.TV(media_id).info()
+
+        elif media_type == "movie":
+            return tmdb.Movies(media_id).info()
+
+        return {}
+
+    except Exception:
+        return {}
+
+def parse_media_details(details: dict, media_type: str) -> tuple[str, int]:
+    """
+    Extract (title, year) from a TMDB details dict.
+    """
+    if not details:
+        return ("", 0)
+
+    # TV → first_air_date, Movie → release_date
+    date_key = "first_air_date" if media_type == "tv" else "release_date"
+
+    # Title extraction logic used in your original function
+    title = details.get("name") or details.get("title", "") or ""
+
+    # Parse year from YYYY-MM-DD (or handle missing/bad formats)
+    year = 0
+    date_str = details.get(date_key)
+
+    if date_str and len(date_str) >= 4:
+        try:
+            year = int(date_str[:4])
+        except ValueError:
+            pass
+
+    return (title, year)
+
+
+def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
+    """
+    Fetch general info (title and year) about a TV show or movie from TMDB.
+    Now split into retrieval + parsing for modularity.
+    """
+    details = fetch_tmdb_object_details(media_id, media_type)
+    return parse_media_details(details, media_type)
+
+
 def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
     """
     Fetch general info (title and year) about a TV show or movie from TMDB.

--- a/functions/tmdb_client.py
+++ b/functions/tmdb_client.py
@@ -1,81 +1,3 @@
-<<<<<<< HEAD
-import tmdbsimple as tmdb
-
-def search_media_by_title(media_title: str, media_type: str) -> list[tmdb.tv.TV] | list[tmdb.movies.Movies]:
-    """
-    Search TMDB for media by title
-    Returns:
-        List of possible TMDB matches
-    """
-    try:
-        tmdb_objects = []
-
-        if media_type == 'tv':
-            results = tmdb.Search().tv(query=media_title)
-            for result in results.get('results', []):
-                media_id = result['id']
-                tmdb_object = tmdb.TV(media_id)
-                tmdb_objects.append(tmdb_object)
-
-            return tmdb_objects
-
-        elif media_type == 'movie':
-            results = tmdb.Search().movie(query=media_title)
-            for result in results.get('results', []):
-                media_id = result['id']
-                tmdb_object = tmdb.Movies(media_id)
-                tmdb_objects.append(tmdb_object)
-
-            return tmdb_objects
-
-        else:
-            return []   # Handle unexpected media_type
-
-    except Exception:
-        return []
-
-def fetch_tmdb_object_details(media_id: int, media_type: str) -> dict:
-    """
-    Retrieve TMDB info() result for either TV or Movie.
-    Returns {} on failure.
-    """
-    try:
-        if media_type == "tv":
-            return tmdb.TV(media_id).info()
-
-        elif media_type == "movie":
-            return tmdb.Movies(media_id).info()
-
-        return {}
-    except Exception:
-        return {}
-
-def parse_media_details(details: dict, media_type: str) -> tuple[str, int]:
-    """
-    Extract (title, year) from a TMDB details dict.
-    """
-    if not details:
-        return ("", 0)
-
-    # TV → first_air_date, Movie → release_date
-    date_key = "first_air_date" if media_type == "tv" else "release_date"
-
-    # Title extraction logic used in your original function
-    title = details.get("name") or details.get("title", "") or ""
-
-    # Parse year from YYYY-MM-DD (or handle missing/bad formats)
-    year = 0
-    date_str = details.get(date_key)
-
-    if date_str and len(date_str) >= 4:
-        try:
-            year = int(date_str[:4])
-        except ValueError:
-            pass
-
-    return (title, year)
-
-=======
 import tmdbsimple as tmdb
 
 
@@ -157,7 +79,6 @@ def parse_media_details(details: dict, media_type: str) -> tuple[str, int]:
     return (title, year)
 
 
->>>>>>> dba746d (commented out the duplicate get_media_info function)
 def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
     """
     Fetch general info (title and year) about a TV show or movie from TMDB.
@@ -166,47 +87,6 @@ def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
     details = fetch_tmdb_object_details(media_id, media_type)
     return parse_media_details(details, media_type)
 
-<<<<<<< HEAD
-def get_episode_title(media_id: int, season_num: int, episode_num: int) -> str:
-    """
-    Returns the episode title.
-    If it cannot be found a blank string is returned.
-    """
-
-    if not media_id or not season_num or not episode_num:
-        return ""
-
-    try:
-        season_info = tmdb.TV_Seasons(media_id, season_num).info()
-        episode_title = next(
-            (ep for ep in season_info.get("episodes", [])
-             if ep.get("episode_number") == int(episode_num)),
-            {}
-        ).get("name", "")
-    except Exception as e:
-        print(e)
-        episode_title = ""
-        pass
-
-    return episode_title
-
-if __name__ == "__main__":
-    from config import load_config
-    CONFIG = load_config()
-    tmdb.API_KEY = CONFIG.tmdb_api_key
-    tmdb.REQUESTS_TIMEOUT = 5
-    print("--- Running metadata.py tests ---")
-    # Inception movie test
-    title, year = get_media_info(media_id=27205, media_type='movie')
-    print(f"Test Result (Inception): {title} ({year})")
-
-    # No year tv test
-    title, year = get_media_info(media_id=8234, media_type='tv')
-    print(f"Test Result (7 La - Missing year): {title} ({year})")
-
-    # Get title test...
-    print(get_episode_title(209867, '1', '12'))
-=======
 
 # NOTE: Duplicate definition intentionally commented out to avoid shadowing the
 # modular version above. Leaving it here for reference during ongoing refactor.
@@ -295,4 +175,3 @@ if __name__ == "__main__":
 
     # Get title test...
     print(get_episode_title(209867, '1', '12'))
->>>>>>> dba746d (commented out the duplicate get_media_info function)

--- a/functions/tmdb_client.py
+++ b/functions/tmdb_client.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import tmdbsimple as tmdb
 
 def search_media_by_title(media_title: str, media_type: str) -> list[tmdb.tv.TV] | list[tmdb.movies.Movies]:
@@ -74,6 +75,89 @@ def parse_media_details(details: dict, media_type: str) -> tuple[str, int]:
 
     return (title, year)
 
+=======
+import tmdbsimple as tmdb
+
+
+def search_media_by_title(media_title: str, media_type: str) -> list[tmdb.tv.TV] | list[tmdb.movies.Movies]:
+    """
+    Search TMDB for media by title
+
+    Returns:
+        List of possible TMDB matches
+    """
+    try:
+        tmdb_objects = []
+
+        if media_type == 'tv':
+            results = tmdb.Search().tv(query=media_title)
+            for result in results.get('results', []):
+                media_id = result['id']
+                tmdb_object = tmdb.TV(media_id)
+                tmdb_objects.append(tmdb_object)
+            
+            return tmdb_objects
+        
+        elif media_type == 'movie':
+            results = tmdb.Search().movie(query=media_title)
+            for result in results.get('results', []):
+                media_id = result['id']
+                tmdb_object = tmdb.Movies(media_id)
+                tmdb_objects.append(tmdb_object)
+            
+            return tmdb_objects
+        
+        else:
+            return []   # Handle unexpected media_type
+        
+    except Exception:
+        return []
+
+
+def fetch_tmdb_object_details(media_id: int, media_type: str) -> dict:
+    """
+    Retrieve TMDB info() result for either TV or Movie.
+    Returns {} on failure.
+    """
+    try:
+        if media_type == "tv":
+            return tmdb.TV(media_id).info()
+
+        elif media_type == "movie":
+            return tmdb.Movies(media_id).info()
+
+        return {}
+
+    except Exception:
+        return {}
+
+def parse_media_details(details: dict, media_type: str) -> tuple[str, int]:
+    """
+    Extract (title, year) from a TMDB details dict.
+    """
+    if not details:
+        return ("", 0)
+
+    # TV → first_air_date, Movie → release_date
+    date_key = "first_air_date" if media_type == "tv" else "release_date"
+
+    # Title extraction logic used in your original function
+    title = details.get("name") or details.get("title", "") or ""
+
+    # Parse year from YYYY-MM-DD (or handle missing/bad formats)
+    year = 0
+    date_str = details.get(date_key)
+
+    if date_str and len(date_str) >= 4:
+        try:
+            year = int(date_str[:4])
+        except ValueError:
+            pass
+
+    return (title, year)
+
+
+>>>>>>> dba746d (commented out the duplicate get_media_info function)
 def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
     """
     Fetch general info (title and year) about a TV show or movie from TMDB.
@@ -82,6 +166,7 @@ def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
     details = fetch_tmdb_object_details(media_id, media_type)
     return parse_media_details(details, media_type)
 
+<<<<<<< HEAD
 def get_episode_title(media_id: int, season_num: int, episode_num: int) -> str:
     """
     Returns the episode title.
@@ -121,3 +206,93 @@ if __name__ == "__main__":
 
     # Get title test...
     print(get_episode_title(209867, '1', '12'))
+=======
+
+# NOTE: Duplicate definition intentionally commented out to avoid shadowing the
+# modular version above. Leaving it here for reference during ongoing refactor.
+# def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
+#     """
+#     Fetch general info (title and year) about a TV show or movie from TMDB.
+#
+#     Returns:
+#         tuple[str, int]: A tuple containing (title: str, year: int).
+#                          Returns ('', 0) on any failure or if date data is missing.
+#     """
+#     try:
+#         if media_type == 'tv':
+#             tmdb_object = tmdb.TV(media_id)
+#             details = tmdb_object.info()
+#             date_key = 'first_air_date'
+#
+#         elif media_type == 'movie':
+#             tmdb_object = tmdb.Movies(media_id)
+#             details = tmdb_object.info()
+#             date_key = 'release_date'
+#
+#         else:
+#             return ('', 0)  # Handle unexpected media_type
+#
+#         # Extract title
+#         title = details.get('name') or details.get('title', '')
+#
+#         # Extract year
+#         date_str = details.get(date_key)
+#         year = 0
+#         if date_str and len(date_str) >= 4:
+#             try:
+#                 # Only attempt to convert the first 4 characters to an integer
+#                 year = int(date_str[:4])
+#             except ValueError:
+#                 # If int conversion fails (e.g., date is "TBD"), year remains 0
+#                 pass
+#
+#         return (title, year)
+#
+#     except Exception:
+#         return ('', 0)
+
+
+def get_episode_title(media_id: int, season_num: int, episode_num: int) -> str:
+    """
+    Returns the episode title.
+    If it cannot be found a blank string is returned.
+    """
+
+    if not media_id or not season_num or not episode_num:
+        return ""
+
+    try:
+        season_info = tmdb.TV_Seasons(media_id, season_num).info()
+        episode_title = next(
+            (ep for ep in season_info.get("episodes", [])
+             if ep.get("episode_number") == int(episode_num)),
+            {}
+        ).get("name", "")
+    except Exception as e:
+        print(e)
+        episode_title = ""
+        pass
+
+    return episode_title
+
+
+if __name__ == "__main__":
+    from config import load_config
+
+    CONFIG = load_config()
+    tmdb.API_KEY = CONFIG.tmdb_api_key
+    tmdb.REQUESTS_TIMEOUT = 5
+
+    print("--- Running metadata.py tests ---")
+
+    # Inception movie test
+    title, year = get_media_info(media_id=27205, media_type='movie')
+    print(f"Test Result (Inception): {title} ({year})")
+
+    # No year tv test
+    title, year = get_media_info(media_id=8234, media_type='tv')
+    print(f"Test Result (7 La - Missing year): {title} ({year})")
+
+    # Get title test...
+    print(get_episode_title(209867, '1', '12'))
+>>>>>>> dba746d (commented out the duplicate get_media_info function)

--- a/functions/tmdb_client.py
+++ b/functions/tmdb_client.py
@@ -1,10 +1,8 @@
 import tmdbsimple as tmdb
 
-
 def search_media_by_title(media_title: str, media_type: str) -> list[tmdb.tv.TV] | list[tmdb.movies.Movies]:
     """
     Search TMDB for media by title
-
     Returns:
         List of possible TMDB matches
     """
@@ -17,24 +15,23 @@ def search_media_by_title(media_title: str, media_type: str) -> list[tmdb.tv.TV]
                 media_id = result['id']
                 tmdb_object = tmdb.TV(media_id)
                 tmdb_objects.append(tmdb_object)
-            
+
             return tmdb_objects
-        
+
         elif media_type == 'movie':
             results = tmdb.Search().movie(query=media_title)
             for result in results.get('results', []):
                 media_id = result['id']
                 tmdb_object = tmdb.Movies(media_id)
                 tmdb_objects.append(tmdb_object)
-            
+
             return tmdb_objects
-        
+
         else:
             return []   # Handle unexpected media_type
-        
+
     except Exception:
         return []
-
 
 def fetch_tmdb_object_details(media_id: int, media_type: str) -> dict:
     """
@@ -49,7 +46,6 @@ def fetch_tmdb_object_details(media_id: int, media_type: str) -> dict:
             return tmdb.Movies(media_id).info()
 
         return {}
-
     except Exception:
         return {}
 
@@ -78,7 +74,6 @@ def parse_media_details(details: dict, media_type: str) -> tuple[str, int]:
 
     return (title, year)
 
-
 def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
     """
     Fetch general info (title and year) about a TV show or movie from TMDB.
@@ -86,49 +81,6 @@ def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
     """
     details = fetch_tmdb_object_details(media_id, media_type)
     return parse_media_details(details, media_type)
-
-
-def get_media_info(media_id: int, media_type: str) -> tuple[str, int]:
-    """
-    Fetch general info (title and year) about a TV show or movie from TMDB.
-
-    Returns:
-        tuple[str, int]: A tuple containing (title: str, year: int).
-                         Returns ('', 0) on any failure or if date data is missing.
-    """
-    try:
-        if media_type == 'tv':
-            tmdb_object = tmdb.TV(media_id)
-            details = tmdb_object.info()
-            date_key = 'first_air_date'
-
-        elif media_type == 'movie':
-            tmdb_object = tmdb.Movies(media_id)
-            details = tmdb_object.info()
-            date_key = 'release_date'
-
-        else:
-            return ('', 0)  # Handle unexpected media_type
-
-        # Extract title
-        title = details.get('name') or details.get('title', '')
-
-        # Extract year
-        date_str = details.get(date_key)
-        year = 0
-        if date_str and len(date_str) >= 4:
-            try:
-                # Only attempt to convert the first 4 characters to an integer
-                year = int(date_str[:4])
-            except ValueError:
-                # If int conversion fails (e.g., date is "TBD"), year remains 0
-                pass
-
-        return (title, year)
-
-    except Exception:
-        return ('', 0)
-
 
 def get_episode_title(media_id: int, season_num: int, episode_num: int) -> str:
     """
@@ -153,16 +105,12 @@ def get_episode_title(media_id: int, season_num: int, episode_num: int) -> str:
 
     return episode_title
 
-
 if __name__ == "__main__":
     from config import load_config
-
     CONFIG = load_config()
     tmdb.API_KEY = CONFIG.tmdb_api_key
     tmdb.REQUESTS_TIMEOUT = 5
-
     print("--- Running metadata.py tests ---")
-
     # Inception movie test
     title, year = get_media_info(media_id=27205, media_type='movie')
     print(f"Test Result (Inception): {title} ({year})")

--- a/input.py
+++ b/input.py
@@ -166,25 +166,25 @@ if defaultjob['type'] == 'tv':
         # OUTPUT: pathtocd/Name (Year) {ID} OUTPUT/Season --/
         #         Name (Year) - s00e00 - EpName \[info\].ext
         seasonepisodestr = f's{int(season):02}e{int(episode):02}'
-        output[-1]['encoded_file'] = OUTPUT_DIR / f'{
-            output[-1]["name"]} ({output[-1]["year"]
-                                  }) {{{output[-1]["id"]}}}' / \
-            f'Season {int(season):02}' / \
-            f'{output[-1]["name"]} ({output[-1]["year"]}) - {
-                seasonepisodestr} - {episode_title}.mkv'
+        output[-1]['encoded_file'] = (
+            OUTPUT_DIR / 
+            f'{output[-1]["name"]} ({output[-1]["year"]}) {{{output[-1]["id"]}}}' /
+            f'Season {int(season):02}' /
+            f'{output[-1]["name"]} ({output[-1]["year"]}) - {seasonepisodestr} - {episode_title}.mkv'
+        )
         output[-1]['encoded_file'] = str(output[-1]['encoded_file'])
-        output[-1]['name'] = f'{output[-1]['name']} - {seasonepisodestr}'
+        output[-1]['name'] = f'{output[-1]["name"]} - {seasonepisodestr}'
 
 # == MOVIE ==
 else:
     if len(filenames) == 1:  # must be movie file
         output.append(deepcopy(defaultjob))
         output[-1]['input_file'] = full_files[0]
-        output[-1]['encoded_file'] = OUTPUT_DIR / \
-            f'{output[-1]["name"]} ({output[-1]["year"]}) {{{
-                output[-1]["id"]}}}{
-            output[-1]["name"]} ({output[-1]["year"]}) {{{
-            output[-1]["id"]}}}.mkv'
+        output[-1]['encoded_file'] = (
+            OUTPUT_DIR /
+            f'{output[-1]["name"]} ({output[-1]["year"]}) {{{output[-1]["id"]}}}' /
+            f'{output[-1]["name"]} ({output[-1]["year"]}) {{{output[-1]["id"]}}}.mkv'
+        )
         output[-1]['encoded_file'] = str(output[-1]['encoded_file'])
     else:
         full_files.sort(key=lambda f: os.path.getsize(f), reverse=True)
@@ -196,11 +196,10 @@ else:
         # Main file
         output.append(deepcopy(defaultjob))
         output[-1]['input_file'] = biggest
-        middle_segment = f'{output[-1]["name"]} ({
-            output[-1]["year"]}) {
-            {{output[-1]["id"]}}}{
-            output[-1]["name"]} ({output[-1]["year"]}) {
-            {{output[-1]["id"]}}}.mkv'
+        middle_segment = (
+            f'{output[-1]["name"]} ({output[-1]["year"]}) {{{output[-1]["id"]}}}' /
+            f'{output[-1]["name"]} ({output[-1]["year"]}) {{{output[-1]["id"]}}}.mkv'
+        )
         output[-1]['encoded_file'] = OUTPUT_DIR / middle_segment
         output[-1]['encoded_file'] = str(output[-1]['encoded_file'])
 
@@ -209,8 +208,7 @@ else:
             output.append(deepcopy(defaultjob))
             output[-1]['input_file'] = f
 
-            middle_segment = f'{
-                output[-1]["name"]} ({output[-1]["year"]}) {{{output[-1]["id"]}}}'
+            middle_segment = f'{output[-1]["name"]} ({output[-1]["year"]}) {{{output[-1]["id"]}}}'
             final_file_name = Path(f).name
             output[-1]['encoded_file'] = OUTPUT_DIR / \
                 middle_segment / 'extras' / final_file_name

--- a/input.py
+++ b/input.py
@@ -128,7 +128,7 @@ sname, syear = '', 0
 tmdbid = None
 
 def is_tmdb_id(text: str) -> bool:
-    return text.startswith('tmdb-') or text.isdigit()
+    return text.startswith('tmdb-')
 
 # If user provided an ID, normalize and fetch info
 if is_tmdb_id(raw_id_or_title):

--- a/input.py
+++ b/input.py
@@ -127,6 +127,11 @@ def parse_episode_code(episode_code: str):
 #     sname, syear = '', 0
 
 raw_id_or_title = survey.routines.input('ID or Title: ', value='').strip()
+if not raw_id_or_title:
+    # If no ID or title provided, prompt user to enter a TMDB ID.
+    print("No ID or title provided; please enter a TMDB ID.")
+    raw_id_or_title = survey.routines.input('ID or Title: ', value='').strip()
+
 mediatypes = ('tv', 'movie')
 defaultjob['type'] = mediatypes[survey.routines.select(
     'Type: ', options=mediatypes)]

--- a/input.py
+++ b/input.py
@@ -5,7 +5,7 @@ import tmdbsimple as tmdb
 from copy import deepcopy
 import time
 import json
-from functions.tmdb_client import get_media_info, get_episode_title
+from functions.tmdb_client import get_media_info, get_episode_title, search_media_by_title
 from functions.config import load_config
 from pathlib import Path
 

--- a/input.py
+++ b/input.py
@@ -114,18 +114,61 @@ def parse_episode_code(episode_code: str):
 
 
 # == MAIN LOGIC ==
-defaultjob['id'] = survey.routines.input('ID: ', value='tmdb-').strip()
-ontmdb = defaultjob['id'].startswith('tmdb-')
+# defaultjob['id'] = survey.routines.input('ID: ', value='tmdb-').strip()
+# ontmdb = defaultjob['id'].startswith('tmdb-')
+# mediatypes = ('tv', 'movie')
+# defaultjob['type'] = mediatypes[survey.routines.select(
+#     'Type: ', options=mediatypes)]
+
+# if ontmdb:
+#     tmdbid = defaultjob['id'][5:]
+#     sname, syear = get_media_info(tmdbid, defaultjob['type'])
+# else:
+#     sname, syear = '', 0
+
+raw_id_or_title = survey.routines.input('ID or Title: ', value='').strip()
 mediatypes = ('tv', 'movie')
 defaultjob['type'] = mediatypes[survey.routines.select(
     'Type: ', options=mediatypes)]
+ontmdb = False
+sname, syear = '', 0
+tmdbid = None
 
-if ontmdb:
-    tmdbid = defaultjob['id'][5:]
+def is_tmdb_id(text: str) -> bool:
+    return text.startswith('tmdb-') or text.isdigit()
+
+# If user provided an ID, normalize and fetch info
+if is_tmdb_id(raw_id_or_title):
+    tmdbid = raw_id_or_title[5:] if raw_id_or_title.startswith('tmdb-') else raw_id_or_title
+    defaultjob['id'] = f"tmdb-{tmdbid}"
+    ontmdb = True
     sname, syear = get_media_info(tmdbid, defaultjob['type'])
 else:
-    sname, syear = '', 0
-
+    # Treat input as a title; search TMDB and select a match
+    results = search_media_by_title(raw_id_or_title, defaultjob['type'])
+    if results:
+        choices = []
+        for res in results:
+            media_id = getattr(res, "id", None)
+            if media_id is None:
+                continue
+            title, year = get_media_info(media_id, defaultjob['type'])
+            label = f"{title or 'Unknown'}{f' ({year})' if year else ''} [{media_id}]"
+            choices.append((label, (media_id, title, year)))
+        if choices:
+            sel = survey.routines.select("Select TMDB match:", options=[c[0] for c in choices])
+            media_id, title, year = choices[sel][1]
+            defaultjob['id'] = f"tmdb-{media_id}"
+            tmdbid = media_id
+            ontmdb = True
+            sname, syear = title, year
+    if not ontmdb:
+        defaultjob['id'] = survey.routines.input('ID: ', value='tmdb-').strip()
+        ontmdb = defaultjob['id'].startswith('tmdb-')
+        if ontmdb:
+            tmdbid = defaultjob['id'][5:]
+            sname, syear = get_media_info(tmdbid, defaultjob['type'])
+    
 defaultjob['name'] = survey.routines.input('Name: ', value=sname)
 defaultjob['year'] = survey.routines.numeric(
     'Year: ', value=int(syear), decimal=False)

--- a/input.py
+++ b/input.py
@@ -114,18 +114,6 @@ def parse_episode_code(episode_code: str):
 
 
 # == MAIN LOGIC ==
-# defaultjob['id'] = survey.routines.input('ID: ', value='tmdb-').strip()
-# ontmdb = defaultjob['id'].startswith('tmdb-')
-# mediatypes = ('tv', 'movie')
-# defaultjob['type'] = mediatypes[survey.routines.select(
-#     'Type: ', options=mediatypes)]
-
-# if ontmdb:
-#     tmdbid = defaultjob['id'][5:]
-#     sname, syear = get_media_info(tmdbid, defaultjob['type'])
-# else:
-#     sname, syear = '', 0
-
 raw_id_or_title = survey.routines.input('ID or Title: ', value='').strip()
 if not raw_id_or_title:
     # If no ID or title provided, prompt user to enter a TMDB ID.

--- a/input.py
+++ b/input.py
@@ -138,7 +138,11 @@ if is_tmdb_id(raw_id_or_title):
     sname, syear = get_media_info(tmdbid, defaultjob['type'])
 else:
     # Treat input as a title; search TMDB and select a match
-    results = search_media_by_title(raw_id_or_title, defaultjob['type'])
+    try:
+        results = search_media_by_title(raw_id_or_title, defaultjob['type'])
+    except Exception as e:
+        print("TMDB search failed. Please enter a TMDB ID instead.")
+        results = []
     if results:
         choices = []
         for res in results:

--- a/tests/test_tmdb_client.py
+++ b/tests/test_tmdb_client.py
@@ -1,0 +1,105 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Add the project root to sys.path so we can import functions
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from functions.tmdb_client import (
+    search_media_by_title,
+    fetch_tmdb_object_details,
+    parse_media_details,
+    get_media_info
+)
+
+class TestTMDBClient(unittest.TestCase):
+
+    # --- TEST 1: Parsing Logic (Mandi's Refactor) ---
+    def test_parse_media_details_movie(self):
+        """Test extraction of title and year from a standard movie response."""
+        mock_data = {
+            "title": "Inception",
+            "release_date": "2010-07-16"
+        }
+        title, year = parse_media_details(mock_data, "movie")
+        self.assertEqual(title, "Inception")
+        self.assertEqual(year, 2010)
+
+    def test_parse_media_details_tv(self):
+        """Test extraction of name and year from a standard TV response."""
+        mock_data = {
+            "name": "Breaking Bad",
+            "first_air_date": "2008-01-20"
+        }
+        title, year = parse_media_details(mock_data, "tv")
+        self.assertEqual(title, "Breaking Bad")
+        self.assertEqual(year, 2008)
+
+    def test_parse_media_details_missing_date(self):
+        """Test behavior when date is missing or invalid."""
+        mock_data = {"title": "Unknown Movie"}
+        # Should return title and 0 for year
+        self.assertEqual(parse_media_details(mock_data, "movie"), ("Unknown Movie", 0))
+
+        mock_data_bad_date = {"title": "TBD Movie", "release_date": ""}
+        self.assertEqual(parse_media_details(mock_data_bad_date, "movie"), ("TBD Movie", 0))
+
+    # --- TEST 2: API Integration (Martin's Task) ---
+    @patch('functions.tmdb_client.tmdb.Search')
+    def test_search_media_by_title_found(self, MockSearch):
+        """Test searching for a title that exists."""
+        mock_search_instance = MockSearch.return_value
+        mock_search_instance.tv.return_value = {
+            'results': [{'id': 123, 'name': 'Test Show'}]
+        }
+
+        results = search_media_by_title("Test Show", "tv")
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results) 
+
+    @patch('functions.tmdb_client.tmdb.Search')
+    def test_search_media_by_title_empty(self, MockSearch):
+        """Test searching for a title with no results."""
+        mock_search_instance = MockSearch.return_value
+        mock_search_instance.movie.return_value = {'results': []}
+
+        results = search_media_by_title("Nonexistent Movie", "movie")
+        self.assertEqual(results, [])
+
+    # --- TEST 3: Error Handling & Edge Cases (Eshar's Task) ---
+    @patch('functions.tmdb_client.tmdb.Movies')
+    def test_fetch_details_network_error(self, MockMovies):
+        """
+        Simulate a network error (Exception) when fetching details.
+        Should handle gracefully and return empty dict.
+        """
+        mock_instance = MockMovies.return_value
+        mock_instance.info.side_effect = Exception("Network Timeout")
+
+        result = fetch_tmdb_object_details(550, "movie")
+        self.assertEqual(result, {})
+
+    def test_get_media_info_integration(self):
+        """
+        Test the full flow of get_media_info using the refactored pieces.
+        We assume fetch and parse work, just checking the handoff.
+        """
+        with patch('functions.tmdb_client.fetch_tmdb_object_details') as mock_fetch:
+            with patch('functions.tmdb_client.parse_media_details') as mock_parse:
+
+                # Setup return values
+                mock_fetch.return_value = {"some": "data"}
+                mock_parse.return_value = ("The Matrix", 1999)
+
+                # Execute
+                result = get_media_info(123, "movie")
+
+                # Assert
+                mock_fetch.assert_called_once_with(123, "movie")
+                mock_parse.assert_called_once_with({"some": "data"}, "movie")
+                self.assertEqual(result, ("The Matrix", 1999))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
Refactors TMDB lookup logic, adds title based search for the TUI, and updates input flow to support both title selection and manual TMDB ID entry.

### Changes
#### functions/tmdb_client.py
- Added `search_media_by_title(media_title: str, media_type: str)` for TUI support
- Refactored `get_media_info(media_id: int, media_type: str)`
  - Added `fetch_tmdb_object_details(media_id, media_type)`
  - Added `parse_media_details(details, media_type)`
#### input.py
- Input now accepts a media title or TMDB ID; title search shows TMDB results, lets the user pick one, and pre-fills ID/name/year, with manual ID fallback intact.
- Added guardrails for empty input and TMDB search failures in the prompt flow.
- Cleaned up TMDB client merge state (single modular `get_media_info`, optional legacy version commented for reference).
#### tests/test_tmdb_client.py
- Used for testing

### Testing
- Added unit tests covering parsing logic, TMDB search behavior, error handling, and the full `get_media_info` flow.
- `python input.py` with valid `TMDB_API_KEY`: entered a title (Inception), selected result: ID/name/year populated; ran through quality/file selection steps.
- Manual ID path: entered tmdb- to confirm it still works.
- Empty input prompt now reprompts for TMDB ID.

Closes #6 